### PR TITLE
ISSUE #11 Hydra client lacks proxy support

### DIFF
--- a/hydra-client/src/main/java/com/pandora/hydra/client/HydraClient.java
+++ b/hydra-client/src/main/java/com/pandora/hydra/client/HydraClient.java
@@ -83,8 +83,13 @@ public class HydraClient {
      */
     static Proxy createProxyIfSpecified() {
         String proxyHost = System.getProperty("http.proxyHost");
-        if (proxyHost == null || proxyHost.isEmpty()) {
-            System.out.println("Invalid http.proxyHost specified; not enabling proxy.");
+        if (proxyHost == null) {
+            // No host specified - not an error; just an indication we don't want to use a proxy
+            return null;
+        }
+        if (proxyHost.isEmpty()) {
+            // Host specified as empty string - this is an error
+            System.out.println("http.proxyHost is empty; not enabling proxy.");
             return null;
         }
         String proxyPortString = System.getProperty("http.proxyPort");

--- a/hydra-client/src/test/java/com/pandora/hydra/client/ProxyConfigTest.java
+++ b/hydra-client/src/test/java/com/pandora/hydra/client/ProxyConfigTest.java
@@ -1,0 +1,28 @@
+package com.pandora.hydra.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ProxyConfigTest {
+    private static void setProxySystemProperties(String host, String port) {
+        System.setProperty("http.proxyPort", port);
+        System.setProperty("http.proxyHost", host);
+    }
+
+    @Test
+    public void test1() {
+        setProxySystemProperties("", "");
+        assertNull(HydraClient.createProxyIfSpecified());
+
+        setProxySystemProperties("", "5005");
+        assertNull(HydraClient.createProxyIfSpecified());
+
+        setProxySystemProperties("foobar.com", "");
+        assertNull(HydraClient.createProxyIfSpecified());
+
+        setProxySystemProperties("foobar.com", "5005");
+        assertNotNull(HydraClient.createProxyIfSpecified());
+    }
+}


### PR DESCRIPTION
Now respects standard -Dhttp.proxyPort -Dhttp.proxyHost system properties for specifying a web proxy.