### PR TITLE
Run a test suite from excludes defined in a file

### DIFF
--- a/hydra-android-gradle-plugin/README.md
+++ b/hydra-android-gradle-plugin/README.md
@@ -125,3 +125,22 @@ After doing so, change the versions of the Hydra plug-ins you specified previous
 
 The plugin can be configured inside of a `hydra { }` configuration block. For more details, refer to the Configuration
 section of `../hydra-gradle-plugin/README.md`
+
+## Running locally
+
+It's possible to run a subset of tests independent of a hydra server. First, update your hydra configuration to log excludes
+
+```
+hydra {
+    logTestExclusions true
+}
+```
+ 
+this setting will cause each node to write its test exclusions to a file. This file can then be used locally to reproduce a 
+given nodes test group
+
+```
+./gradlew integrationTest_balanced -Phydra.exclusionFile=pathToExcludesFile
+```
+ 
+Reproducing a test group locally can help with debugging errors related to test run order.  

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/BalancedTestFactory.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/BalancedTestFactory.java
@@ -49,13 +49,14 @@ public class BalancedTestFactory<T extends Test, U extends Test> {
             tasksByName.forEach(t -> testTasks.add(verifyAndCastToTest(t, originalTestType)));
         }
 
-		final boolean localRun = hydraExtension.getExclusionFile() != null;
+		String hydraExclusionFile = (String) project.getProperties().get("hydra.exclusionFile");
+		final boolean localRun = hydraExclusionFile != null;
 
 		//defer creation till a balanced test is actually executed
 		final Supplier<HydraClient> clientSupplier;
 		final LazyTestExcluder lazyExcluder;
         if(localRun) {
-        	lazyExcluder = LazyTestExcluder.fromExclusionFile(project, hydraExtension.getExclusionFile());
+        	lazyExcluder = LazyTestExcluder.fromExclusionFile(project, hydraExclusionFile);
         	clientSupplier = () -> null;
 		} else {
 			clientSupplier = () -> {

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/BalancedTestFactory.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/BalancedTestFactory.java
@@ -49,14 +49,21 @@ public class BalancedTestFactory<T extends Test, U extends Test> {
             tasksByName.forEach(t -> testTasks.add(verifyAndCastToTest(t, originalTestType)));
         }
 
-        String projectName = project.getName();
-        //defer creation till a balanced test is actually executed
-        Supplier<HydraClient> clientSupplier = () -> {
-            Configuration configuration = Configuration.newConfigurationFromEnv(buildOverrideMap(hydraExtension));
-            return new HydraClient(configuration);
-        };
+		final boolean localRun = hydraExtension.getExclusionFile() != null;
 
-        LazyTestExcluder lazyExcluder = new LazyTestExcluder(project, clientSupplier);
+		//defer creation till a balanced test is actually executed
+		final Supplier<HydraClient> clientSupplier;
+		final LazyTestExcluder lazyExcluder;
+        if(localRun) {
+        	lazyExcluder = LazyTestExcluder.fromExclusionFile(project, hydraExtension.getExclusionFile());
+        	clientSupplier = () -> null;
+		} else {
+			clientSupplier = () -> {
+				Configuration configuration = Configuration.newConfigurationFromEnv(buildOverrideMap(hydraExtension));
+				return new HydraClient(configuration);
+			};
+			lazyExcluder = LazyTestExcluder.fromHydraServer(project, clientSupplier);
+		}
 
         for (U originalTest : testTasks) {
             T balancedTest = project.getTasks()
@@ -67,23 +74,26 @@ public class BalancedTestFactory<T extends Test, U extends Test> {
             BalancedTestListener testListener = new BalancedTestListener(balancedTest.getProject().getName());
             balancedTest.addTestListener(testListener);
 
-            if(hydraExtension.isBalanceThreads()) {
-                balancedTest.setProperty("balanceThreads", true);
-                balancedTest.setProperty("envOverrides", buildOverrideMap(hydraExtension));
-            }
+            if(!localRun) {
+            	if(hydraExtension.isBalanceThreads()) {
+					balancedTest.setProperty("balanceThreads", true);
+					balancedTest.setProperty("envOverrides", buildOverrideMap(hydraExtension));
+				}
 
-            Task finalizer = project.getTasks().create(balancedTest.getName() + "_finalizer");
-            finalizer.doLast(task -> {
-                try {
-                    clientSupplier.get().postTestRuntimes(new ArrayList<>(testListener.getTests().values()));
-                } catch (IOException e) {
-                    project.getLogger().lifecycle("Problem posting test runtime to hydra server for project " + projectName);
-                    e.printStackTrace();
-                }
-            });
+				Task finalizer = project.getTasks().create(balancedTest.getName() + "_finalizer");
+				finalizer.doLast(task -> {
+					try {
+						clientSupplier.get().postTestRuntimes(new ArrayList<>(testListener.getTests().values()));
+					} catch(IOException e) {
+						project.getLogger()
+							   .lifecycle("Problem posting test runtime to hydra server for project " + project.getName());
+						e.printStackTrace();
+					}
+				});
 
-            //use finalizedBy so that it always runs regardless of whether tests fail or not
-            balancedTest.finalizedBy(finalizer);
+				//use finalizedBy so that it always runs regardless of whether tests fail or not
+				balancedTest.finalizedBy(finalizer);
+			}
         }
     }
 

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
@@ -53,8 +53,6 @@ public class HydraPluginExtension {
      */
     private boolean logTestExclusions;
 
-    private String exclusionFile;
-
     /**
      * How many times (including the initial attempt) should the client attempt network operations before giving up?
      */
@@ -128,14 +126,6 @@ public class HydraPluginExtension {
     public void setLogTestExclusions(boolean logTestExclusions) {
         this.logTestExclusions = logTestExclusions;
     }
-
-	public String getExclusionFile() {
-		return exclusionFile;
-	}
-
-	public void setExclusionFile(String exclusionFile) {
-		this.exclusionFile = exclusionFile;
-	}
 
 	public Integer getNumClientAttempts() {
         return numClientAttempts;

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
@@ -53,6 +53,8 @@ public class HydraPluginExtension {
      */
     private boolean logTestExclusions;
 
+    private String exclusionFile;
+
     public String getHydraServer() {
         return hydraServer;
     }
@@ -116,4 +118,12 @@ public class HydraPluginExtension {
     public void setLogTestExclusions(boolean logTestExclusions) {
         this.logTestExclusions = logTestExclusions;
     }
+
+	public String getExclusionFile() {
+		return exclusionFile;
+	}
+
+	public void setExclusionFile(String exclusionFile) {
+		this.exclusionFile = exclusionFile;
+	}
 }

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/HydraPluginExtension.java
@@ -127,7 +127,7 @@ public class HydraPluginExtension {
         this.logTestExclusions = logTestExclusions;
     }
 
-	public Integer getNumClientAttempts() {
+    public Integer getNumClientAttempts() {
         return numClientAttempts;
     }
 

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/LazyTestExcluder.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/LazyTestExcluder.java
@@ -8,8 +8,16 @@ import org.gradle.api.file.RelativePath;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.specs.Spec;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Set;
@@ -24,20 +32,49 @@ public class LazyTestExcluder implements Spec<FileTreeElement> {
     private final Supplier<HydraClient> hydraClient;
     private final String projectName;
     private final Project project;
+	private final Supplier<Set<String>> exclusionSupplier;
 
     private volatile Set<String> blacklist;
 
-    public LazyTestExcluder(Project project, Supplier<HydraClient> hydraClientSupplier) {
-        this.hydraClient = hydraClientSupplier;
-        this.projectName = project.getName();
-        this.project = project;
-    }
+    private LazyTestExcluder(Project project, Supplier<HydraClient> hydraClientSupplier, Supplier<Set<String>> exclusionSupplier) {
+		this.hydraClient = hydraClientSupplier;
+		this.projectName = project.getName();
+		this.project = project;
+
+		if(exclusionSupplier == null) {
+			this.exclusionSupplier = this::fetchTestExcludesListFromHydraServer;
+		} else {
+			this.exclusionSupplier = exclusionSupplier;
+		}
+	}
+
+	public static LazyTestExcluder fromHydraServer(Project project, Supplier<HydraClient> hydraClientSupplier) {
+		return new LazyTestExcluder(project, hydraClientSupplier, null);
+	}
+
+	public static LazyTestExcluder fromExclusionFile(Project project, String pathToExclusionFile) {
+		Supplier<Set<String>> exclusionSupplier = () -> {
+			Path exclusionPath = Paths.get(pathToExclusionFile);
+			try {
+				return new LinkedHashSet<>(Files.readAllLines(exclusionPath));
+			} catch(IOException e) {
+				throw new GradleException("Unable to read exclusions from " + pathToExclusionFile);
+			}
+		};
+
+		return new LazyTestExcluder(project, () -> null, exclusionSupplier);
+	}
 
     @Override
     public boolean isSatisfiedBy(FileTreeElement fileTreeElement) {
         if(blacklist == null) {
-            fetchTestExcludesListFromHydraServer();
-        }
+            synchronized(this) {
+				if(blacklist == null) {
+					blacklist = exclusionSupplier.get();
+					logTestBlackListIfSpecified();
+				}
+			}
+		}
         if(fileTreeElement.isDirectory()) {
             return false;
         } else {
@@ -71,18 +108,13 @@ public class LazyTestExcluder implements Spec<FileTreeElement> {
         }
     }
 
-    private synchronized void fetchTestExcludesListFromHydraServer() {
-        if(blacklist != null) {
-            return;
-        }
-
+    private Set<String> fetchTestExcludesListFromHydraServer() {
         try {
             // We're switching to project-specific blacklists, but if you run into problems with this
             // for some reason, you can switch back to cumulative blacklists by using the following
             // line instead:
             // blacklist = hydraClient.get().getExcludes();
-            blacklist = hydraClient.get().getExcludes(projectName);
-            logTestBlackListIfSpecified();
+            return hydraClient.get().getExcludes(projectName);
         } catch (IOException e) {
             throw new GradleException("Unable to fetch tests from hydra server for project " + projectName, e);
         }

--- a/hydra-gradle-core/src/main/java/com/pandora/hydra/LazyTestExcluder.java
+++ b/hydra-gradle-core/src/main/java/com/pandora/hydra/LazyTestExcluder.java
@@ -32,49 +32,49 @@ public class LazyTestExcluder implements Spec<FileTreeElement> {
     private final Supplier<HydraClient> hydraClient;
     private final String projectName;
     private final Project project;
-	private final Supplier<Set<String>> exclusionSupplier;
+    private final Supplier<Set<String>> exclusionSupplier;
 
     private volatile Set<String> blacklist;
 
     private LazyTestExcluder(Project project, Supplier<HydraClient> hydraClientSupplier, Supplier<Set<String>> exclusionSupplier) {
-		this.hydraClient = hydraClientSupplier;
-		this.projectName = project.getName();
-		this.project = project;
+        this.hydraClient = hydraClientSupplier;
+        this.projectName = project.getName();
+        this.project = project;
 
-		if(exclusionSupplier == null) {
-			this.exclusionSupplier = this::fetchTestExcludesListFromHydraServer;
-		} else {
-			this.exclusionSupplier = exclusionSupplier;
-		}
-	}
+        if(exclusionSupplier == null) {
+            this.exclusionSupplier = this::fetchTestExcludesListFromHydraServer;
+        } else {
+            this.exclusionSupplier = exclusionSupplier;
+        }
+    }
 
-	public static LazyTestExcluder fromHydraServer(Project project, Supplier<HydraClient> hydraClientSupplier) {
-		return new LazyTestExcluder(project, hydraClientSupplier, null);
-	}
+    public static LazyTestExcluder fromHydraServer(Project project, Supplier<HydraClient> hydraClientSupplier) {
+        return new LazyTestExcluder(project, hydraClientSupplier, null);
+    }
 
-	public static LazyTestExcluder fromExclusionFile(Project project, String pathToExclusionFile) {
-		Supplier<Set<String>> exclusionSupplier = () -> {
-			Path exclusionPath = Paths.get(pathToExclusionFile);
-			try {
-				return new LinkedHashSet<>(Files.readAllLines(exclusionPath));
-			} catch(IOException e) {
-				throw new GradleException("Unable to read exclusions from " + pathToExclusionFile);
-			}
-		};
+    public static LazyTestExcluder fromExclusionFile(Project project, String pathToExclusionFile) {
+        Supplier<Set<String>> exclusionSupplier = () -> {
+            Path exclusionPath = Paths.get(pathToExclusionFile);
+            try {
+                return new LinkedHashSet<>(Files.readAllLines(exclusionPath));
+            } catch(IOException e) {
+                throw new GradleException("Unable to read exclusions from " + pathToExclusionFile);
+            }
+        };
 
-		return new LazyTestExcluder(project, () -> null, exclusionSupplier);
-	}
+        return new LazyTestExcluder(project, () -> null, exclusionSupplier);
+    }
 
     @Override
     public boolean isSatisfiedBy(FileTreeElement fileTreeElement) {
         if(blacklist == null) {
             synchronized(this) {
-				if(blacklist == null) {
-					blacklist = exclusionSupplier.get();
-					logTestBlackListIfSpecified();
-				}
-			}
-		}
+                if(blacklist == null) {
+                    blacklist = exclusionSupplier.get();
+                    logTestBlackListIfSpecified();
+                }
+            }
+        }
         if(fileTreeElement.isDirectory()) {
             return false;
         } else {


### PR DESCRIPTION
Allows specifying a file that contains all of the exclusions to use for a test run. This can be useful when trying to reproduce test failures that only occur when running on the server.

Usage is:
-enable logging via the plugin option	`logTestExclusions true`
-download the exclusion file from jenkins after a test run
-./gradlew integrationTest_balanced -Phydra.exclusionFile=whatever